### PR TITLE
Add wallet auth flow

### DIFF
--- a/abroad-ui/src/App.tsx
+++ b/abroad-ui/src/App.tsx
@@ -5,6 +5,7 @@ import Recipients from "./pages/Recipients";
 import Integrations from "./pages/Integrations";
 import ProtectedRoute from "./components/ProtectedRoute"; // Import the ProtectedRoute component
 import { LanguageProvider } from './contexts/LanguageContext';
+import { WalletAuthProvider } from './context/WalletAuthContext';
 import { Settings } from "./pages/Settings";
 import Pool from "./pages/Pool";
 // Mobile pages
@@ -34,7 +35,8 @@ function App() {
       }}
     >
       <LanguageProvider>
-        <Router>
+        <WalletAuthProvider>
+          <Router>
           <Routes>
             <Route path="/" element={<WebSwap />} />
             {/* Wrap protected routes with ProtectedRoute */} 
@@ -52,6 +54,7 @@ function App() {
 
           </Routes>
         </Router>
+        </WalletAuthProvider>
       </LanguageProvider>
     </BluxProvider>
   );

--- a/abroad-ui/src/context/WalletAuthContext.tsx
+++ b/abroad-ui/src/context/WalletAuthContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useBlux } from '@bluxcc/react';
+import { walletAuth } from '../services/walletAuth';
+
+interface WalletAuthState {
+  token: string | null;
+}
+
+const WalletAuthContext = createContext<WalletAuthState>({ token: null });
+
+export const WalletAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, isAuthenticated } = useBlux();
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+
+  useEffect(() => {
+    async function doAuth() {
+      if (
+        isAuthenticated &&
+        user?.wallet?.address &&
+        typeof (user.wallet as any).signMessage === 'function'
+      ) {
+        try {
+          const newToken = await walletAuth(user.wallet.address, {
+            signMessage: (user.wallet as any).signMessage,
+          });
+          localStorage.setItem('token', newToken);
+          setToken(newToken);
+        } catch (err) {
+          console.error('Wallet authentication failed', err);
+        }
+      }
+    }
+    doAuth();
+  }, [isAuthenticated, user]);
+
+  return (
+    <WalletAuthContext.Provider value={{ token }}>
+      {children}
+    </WalletAuthContext.Provider>
+  );
+};
+
+export const useWalletAuth = () => useContext(WalletAuthContext);
+

--- a/abroad-ui/src/services/walletAuth.ts
+++ b/abroad-ui/src/services/walletAuth.ts
@@ -1,0 +1,23 @@
+import { ethers } from 'ethers';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export async function walletAuth(address: string, signer: { signMessage: (msg: string) => Promise<string> }): Promise<string> {
+  const res = await fetch(`${API_BASE_URL}/walletAuth/challenge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ address }),
+  });
+  if (!res.ok) throw new Error('Failed to fetch challenge');
+  const { nonce } = await res.json();
+  const signature = await signer.signMessage(nonce);
+  const verifyRes = await fetch(`${API_BASE_URL}/walletAuth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ address, signature }),
+  });
+  if (!verifyRes.ok) throw new Error('Failed to verify signature');
+  const { token } = await verifyRes.json();
+  return token as string;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "cors": "^2.8.5",
         "csv-writer": "^1.6.0",
         "dotenv": "^16.4.7",
+        "ethers": "^6.12.1",
         "express": "^5.1.0",
         "firebase-admin": "^13.3.0",
         "gcp-metadata": "^6.1.1",
@@ -66,6 +67,12 @@
         "tsx": "^4.19.2",
         "typescript": "^5.6.3"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -5235,6 +5242,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -7970,6 +7983,100 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/event-target-shim": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cors": "^2.8.5",
     "csv-writer": "^1.6.0",
     "dotenv": "^16.4.7",
+    "ethers": "^6.12.1",
     "express": "^5.1.0",
     "firebase-admin": "^13.3.0",
     "gcp-metadata": "^6.1.1",

--- a/src/controllers/WalletAuthController.ts
+++ b/src/controllers/WalletAuthController.ts
@@ -1,0 +1,66 @@
+import { Body, Controller, Post, Route } from 'tsoa';
+import { randomBytes } from 'crypto';
+import { ethers } from 'ethers';
+import jwt from 'jsonwebtoken';
+
+const challenges = new Map<string, string>();
+
+interface ChallengeRequest {
+  address: string;
+}
+
+interface ChallengeResponse {
+  nonce: string;
+}
+
+interface VerifyRequest {
+  address: string;
+  signature: string;
+}
+
+interface VerifyResponse {
+  token: string;
+}
+
+@Route('walletAuth')
+export class WalletAuthController extends Controller {
+  /**
+   * Request a nonce challenge for the provided wallet address.
+   */
+  @Post('challenge')
+  public async challenge(
+    @Body() body: ChallengeRequest,
+  ): Promise<ChallengeResponse> {
+    const nonce = `0x${randomBytes(16).toString('hex')}`;
+    challenges.set(body.address.toLowerCase(), nonce);
+    return { nonce };
+  }
+
+  /**
+   * Verify a signed challenge and issue a JWT token if valid.
+   */
+  @Post('verify')
+  public async verify(
+    @Body() body: VerifyRequest,
+  ): Promise<VerifyResponse> {
+    const expectedNonce = challenges.get(body.address.toLowerCase());
+    if (!expectedNonce) {
+      this.setStatus(400);
+      throw new Error('No challenge for address');
+    }
+
+    const recovered = ethers.verifyMessage(expectedNonce, body.signature);
+    if (recovered.toLowerCase() !== body.address.toLowerCase()) {
+      this.setStatus(401);
+      throw new Error('Invalid signature');
+    }
+
+    challenges.delete(body.address.toLowerCase());
+    const secret = process.env.JWT_SECRET || 'secret';
+    const token = jwt.sign({ address: body.address.toLowerCase() }, secret, {
+      expiresIn: '1h',
+    });
+    return { token };
+  }
+}
+

--- a/src/ioc.ts
+++ b/src/ioc.ts
@@ -7,6 +7,7 @@ import { PartnerController } from './controllers/PartnerController'
 import { PartnerUserController } from './controllers/PartnerUserController'
 import { PaymentsController } from './controllers/PaymentsController'
 import { QrDecoderController } from './controllers/QrDecoderController'
+import { WalletAuthController } from './controllers/WalletAuthController'
 import { BinanceBalanceUpdatedController } from './controllers/queue/BinanceBalanceUpdatedController'
 import { PaymentSentController } from './controllers/queue/PaymentSentController'
 import { ReceivedCryptoTransactionController } from './controllers/queue/ReceivedCryptoTransactionController'
@@ -149,6 +150,7 @@ container.bind<TransactionsController>(TransactionsController).toSelf().inSingle
 container.bind<KycController>(KycController).toSelf().inSingletonScope()
 container.bind(PaymentsController).toSelf().inSingletonScope()
 container.bind(QrDecoderController).toSelf().inSingletonScope()
+container.bind(WalletAuthController).toSelf().inSingletonScope()
 
 // ILogger
 container.bind<ILogger>(TYPES.ILogger).to(ConsoleLogger).inSingletonScope()


### PR DESCRIPTION
## Summary
- add WalletAuthController to issue nonce challenges and verify wallet signatures
- bind new controller in IoC container
- add ethers dependency
- add walletAuth client helper and WalletAuthContext in UI
- integrate WalletAuthProvider in App to handle wallet login token

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68873f690c548322b99532fbf0e3c8e4