### PR TITLE
fix(ui): responsive layout for small screens in MiniPay flow

### DIFF
--- a/abroad-ui/public/i18n/es.json
+++ b/abroad-ui/public/i18n/es.json
@@ -251,7 +251,7 @@
   "user_verification.subtitle": "Verifica tu cuenta para acceder a todas las funciones.",
   "user_verification.title": "Se requiere verificación de usuario",
 
-  "wait_sign.wait_message": "MiniPay te pedirá que confirmes la transacción.",
+  "wait_sign.wait_message": "Tu billetera te pedirá que confirmes la transacción.",
   "wait_sign.wait_sign": "Confirma tu pago en tu billetera",
 
   "wallet_details.actions.back": "Atrás",

--- a/abroad-ui/src/features/swap/components/TxStatus.tsx
+++ b/abroad-ui/src/features/swap/components/TxStatus.tsx
@@ -354,7 +354,7 @@ const TxStatus = ({
       {error && <div className="text-ab-error text-sm">{error}</div>}
 
       <div
-        className="relative w-full max-w-md min-h-[60vh] rounded-2xl bg-ab-card/5 p-6 backdrop-blur-xl flex flex-col items-center justify-center space-y-4"
+        className="relative w-full max-w-md py-[clamp(2.5rem,8vh,5rem)] rounded-2xl bg-ab-card/5 p-6 backdrop-blur-xl flex flex-col items-center justify-center space-y-4"
         id="bg-container"
       >
         <div>{renderIcon()}</div>

--- a/abroad-ui/src/features/swap/components/TxStatus.tsx
+++ b/abroad-ui/src/features/swap/components/TxStatus.tsx
@@ -220,7 +220,7 @@ const TxStatus = ({
           <div className="mb-8">{renderIcon()}</div>
 
           {/* Title – Figma 17:50 */}
-          <h1 className="mb-2 text-center text-[30px] font-bold leading-9 text-ab-text">
+          <h1 className="mb-2 text-center text-[clamp(1.1rem,5vw,1.6rem)] font-bold leading-tight text-ab-text">
             {t('tx_status.payment_confirmed', 'Payment Confirmed!')}
           </h1>
 

--- a/abroad-ui/src/features/swap/components/TxStatus.tsx
+++ b/abroad-ui/src/features/swap/components/TxStatus.tsx
@@ -16,9 +16,9 @@ import { cn } from '@/shared/utils'
 
 // S6478: component defined at module scope (not inside parent)
 const DetailRow = ({ className, label, value }: { className?: string, label: string, value: React.ReactNode }) => (
-  <div className={cn('flex items-center justify-between border-b border-ab-border pb-[17px]', className)}>
-    <span className="text-base font-normal text-ab-text-3">{label}</span>
-    <span className="text-base font-medium text-ab-text">{value}</span>
+  <div className={cn('flex items-center justify-between border-b border-ab-border pb-[clamp(6px,1.5vh,14px)]', className)}>
+    <span className="text-[clamp(0.7rem,2.5vw,0.875rem)] font-normal text-ab-text-3">{label}</span>
+    <span className="text-[clamp(0.7rem,2.5vw,0.875rem)] font-medium text-ab-text">{value}</span>
   </div>
 )
 
@@ -217,21 +217,21 @@ const TxStatus = ({
       <div className="flex flex-1 flex-col items-center justify-center w-full max-w-[448px]">
         <div className="flex w-full flex-col items-center">
           {/* Success icon – Figma 17:93 */}
-          <div className="mb-8">{renderIcon()}</div>
+          <div className="mb-[clamp(0.5rem,2vh,2rem)]">{renderIcon()}</div>
 
           {/* Title – Figma 17:50 */}
-          <h1 className="mb-2 text-center text-[clamp(1.1rem,5vw,1.6rem)] font-bold leading-tight text-ab-text">
+          <h1 className="mb-1 text-center text-[clamp(1.1rem,5vw,1.6rem)] font-bold leading-tight text-ab-text">
             {t('tx_status.payment_confirmed', 'Payment Confirmed!')}
           </h1>
 
           {/* Subtitle – Figma 17:53 */}
-          <p className="mb-10 text-center text-base font-medium text-ab-text-3">
+          <p className="mb-[clamp(0.5rem,2vh,2rem)] text-center text-[clamp(0.7rem,2.5vw,0.875rem)] font-medium text-ab-text-3">
             {t('tx_status.settled_via', 'Settled via {rail}', { rail: txStatusDetails.rail })}
           </p>
 
           {/* Transaction details card – Figma 17:55 */}
-          <div className="mb-8 w-full overflow-hidden rounded-[24px] border border-ab-border bg-ab-input shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)]">
-            <div className="flex flex-col gap-5 p-6">
+          <div className="mb-[clamp(0.5rem,2vh,2rem)] w-full overflow-hidden rounded-[16px] border border-ab-border bg-ab-input shadow-[0px_1px_2px_0px_rgba(0,0,0,0.05)]">
+            <div className="flex flex-col gap-[clamp(6px,1.5vh,16px)] p-[clamp(0.75rem,3vw,1.5rem)]">
               <DetailRow
                 label={t('tx_status.merchant', 'Merchant')}
                 value={merchant}
@@ -274,8 +274,8 @@ const TxStatus = ({
                 )}
               />
               <div className="flex items-center justify-between">
-                <span className="text-base font-normal text-ab-text-3">{t('tx_status.rail', 'Rail')}</span>
-                <span className="flex items-center gap-2 text-base font-medium text-ab-text">
+                <span className="text-[clamp(0.7rem,2.5vw,0.875rem)] font-normal text-ab-text-3">{t('tx_status.rail', 'Rail')}</span>
+                <span className="flex items-center gap-2 text-[clamp(0.7rem,2.5vw,0.875rem)] font-medium text-ab-text">
                   {CURRENCY_FLAG_URL[targetCurrency] && (
                     <img
                       alt={targetCurrency}
@@ -297,7 +297,7 @@ const TxStatus = ({
 
           {/* Done button – Figma 17:96 */}
           <Button
-            className="w-full rounded-2xl bg-ab-green py-4 text-base font-semibold text-white shadow-[0px_10px_15px_-3px_rgba(16,185,129,0.2),0px_4px_6px_-4px_rgba(16,185,129,0.2)] hover:opacity-95"
+            className="w-full rounded-2xl bg-ab-green py-[clamp(0.6rem,2vh,1rem)] text-[clamp(0.8rem,3vw,1rem)] font-semibold text-white shadow-[0px_10px_15px_-3px_rgba(16,185,129,0.2),0px_4px_6px_-4px_rgba(16,185,129,0.2)] hover:opacity-95"
             onClick={onNewTransaction}
             type="button"
           >

--- a/abroad-ui/src/features/swap/components/UserVerification.tsx
+++ b/abroad-ui/src/features/swap/components/UserVerification.tsx
@@ -68,7 +68,7 @@ const UserVerification = ({ isDark = false, onApproved, onClose }: UserVerificat
   useWebSocketSubscription('kyc.updated', handleKycUpdate)
   return (
     <div className="flex-1 flex items-center justify-center w-full flex-col">
-      <div className="w-full max-w-md min-h-[60vh] bg-[var(--ab-card)] border border-[var(--ab-border)] backdrop-blur-xl rounded-2xl p-4 md:p-6 flex flex-col items-center justify-center space-y-1 lg:space-y-4 text-[var(--ab-text)]">
+      <div className="w-full max-w-md py-[clamp(2.5rem,8vh,5rem)] bg-[var(--ab-card)] border border-[var(--ab-border)] backdrop-blur-xl rounded-2xl p-4 md:p-6 flex flex-col items-center justify-center space-y-1 lg:space-y-4 text-[var(--ab-text)]">
         <button
           aria-label={t('user_verification.close', 'Close')}
           className="fixed top-4 right-4 z-20 rounded-full bg-[var(--ab-bg-card)] border border-[var(--ab-border)] p-2 shadow-md md:top-6 md:right-6"

--- a/abroad-ui/src/features/swap/components/WaitSign.tsx
+++ b/abroad-ui/src/features/swap/components/WaitSign.tsx
@@ -11,7 +11,7 @@ const WaitSign = ({ isDark = false }: WaitSignProps): React.JSX.Element => {
   const { t } = useTranslate()
   return (
     <div className="flex-1 flex items-center justify-center w-full flex-col">
-      <div className="w-full max-w-md min-h-[60vh] bg-[var(--ab-card)] border border-[var(--ab-border)] backdrop-blur-xl rounded-2xl p-4 md:p-6 flex flex-col items-center justify-center space-y-1 lg:space-y-4 text-[var(--ab-text)]">
+      <div className="w-full max-w-md py-[clamp(2.5rem,8vh,5rem)] bg-[var(--ab-card)] border border-[var(--ab-border)] backdrop-blur-xl rounded-2xl p-4 md:p-6 flex flex-col items-center justify-center space-y-1 lg:space-y-4 text-[var(--ab-text)]">
         <IconAnimated
           colors={isDark ? 'primary:#e0f0ec,secondary:#73B9A3' : 'primary:#356E6A,secondary:#26A17B'}
           icon="DocumentSign"

--- a/abroad-ui/src/features/swap/components/WaitSign.tsx
+++ b/abroad-ui/src/features/swap/components/WaitSign.tsx
@@ -23,7 +23,7 @@ const WaitSign = ({ isDark = false }: WaitSignProps): React.JSX.Element => {
           {t('wait_sign.wait_sign', 'Confirm your payment in your wallet')}
         </h2>
         <p className="text-center mb-6 text-[var(--ab-text-secondary)]">
-          {t('wait_sign.wait_message', 'MiniPay will ask you to confirm the transaction.')}
+          {t('wait_sign.wait_message', 'Your wallet will ask you to confirm the transaction.')}
         </p>
       </div>
     </div>

--- a/abroad-ui/src/features/swap/components/WebSwapLayout.tsx
+++ b/abroad-ui/src/features/swap/components/WebSwapLayout.tsx
@@ -59,10 +59,10 @@ const WebSwapLayout: React.FC<WebSwapLayoutProps & WebSwapLayoutSlots> = ({ disc
     <div
       className={cn(
         'w-full min-h-0 flex-1 flex flex-col items-center overflow-x-hidden overflow-y-auto px-3 py-[clamp(0.5rem,2vh,1.5rem)] md:px-4',
-        isMainFlow ? 'hero-gradient justify-start' : 'justify-center',
+        isMainFlow ? 'hero-gradient' : '',
       )}
     >
-      <div className={cn('w-full', isMainFlow ? 'max-w-[576px]' : 'max-w-md')}>
+      <div className={cn('w-full', isMainFlow ? 'max-w-[576px]' : 'max-w-md my-auto')}>
         {renderSwap}
         {disclosure}
       </div>


### PR DESCRIPTION
## Summary

- Remove `justify-center` from the scroll container in `WebSwapLayout` — fixes content being permanently hidden above the viewport on small screens (320–390px). All non-main-flow views are fixed: `txStatus`, `wait-sign`, `confirm-qr`, `kyc-needed`
- Remove `min-h-[60vh]` from `WaitSign` and `TxStatus` in-progress card; replace with `clamp()`-based vertical padding so cards breathe without overflowing on compact devices
- Reduce "Payment Confirmed!" title font size with `clamp()` so it fits on one line on small screens
- Compress `TxStatus` detail table (row gaps, padding, font sizes) with `clamp()` so all 6 rows and the Done button are visible at once on 320×568 and 390×667 viewports

## Test plan

- [ ] Payment Confirmed screen — all detail rows visible without scrolling on 320×568
- [ ] Payment Confirmed screen — title fits on one line on 390×667
- [ ] Wait-sign card — centered with breathing room, no clipping on 390×667
- [ ] TxStatus in-progress card — spinner visible, no clipping on 390×667
- [ ] Desktop (1280px) — no visual regression, centering intact