### PR TITLE
fix(flows): make USDT/CELO→BRL multi-hop corridor work end-to-end

### DIFF
--- a/abroad-server/src/modules/flows/application/FlowDefinitionBuilder.ts
+++ b/abroad-server/src/modules/flows/application/FlowDefinitionBuilder.ts
@@ -66,10 +66,12 @@ export class FlowDefinitionBuilder {
       state = result.state
     }
 
-    return systemSteps.map((step, index) => ({
+    const ordered = systemSteps.map((step, index) => ({
       ...step,
       stepOrder: index + 1,
     }))
+    this.wireAmountSources(ordered)
+    return ordered
   }
 
   private buildAwaitProviderStatus(): FlowSystemStep {
@@ -83,11 +85,15 @@ export class FlowDefinitionBuilder {
 
   private buildBinanceConvert(
     step: Extract<FlowBusinessStep, { type: 'CONVERT' }>,
-  ): { side: 'BUY' | 'SELL', symbol: string } {
-    const symbol = `${step.fromAsset}${step.toAsset}`
+  ): { fromAsset: SupportedCurrency, toAsset: SupportedCurrency } {
+    // Emit the conversion intent only. Binance lists each pair in a single
+    // direction (e.g. USDCUSDT, never USDTUSDC), so the venue-specific trading
+    // symbol and side are resolved at execution time against live exchangeInfo
+    // by the ExchangeConvertStepExecutor — guessing `${from}${to}` + SELL here
+    // produced invalid symbols (e.g. USDTUSDC) for half of all pairs.
     return {
-      side: 'SELL',
-      symbol,
+      fromAsset: step.fromAsset,
+      toAsset: step.toAsset,
     }
   }
 
@@ -268,11 +274,52 @@ export class FlowDefinitionBuilder {
     }
   }
 
+  private findPrecedingStepOrder(steps: FlowSystemStep[], index: number, stepType: FlowStepType): number | undefined {
+    for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+      if (steps[cursor].stepType === stepType) {
+        return steps[cursor].stepOrder
+      }
+    }
+    return undefined
+  }
+
   private isTargetCurrency(value: SupportedCurrency): value is TargetCurrency {
     return Object.values(TargetCurrency).includes(value as TargetCurrency)
   }
 
   private mapVenueToProvider(venue: FlowVenue): 'binance' | 'transfero' {
     return venue === 'BINANCE' ? 'binance' : 'transfero'
+  }
+
+  /**
+   * Propagate REALIZED amounts between money-moving hops. Each hop loses value
+   * to spread/fees, so a step must act on what the previous step actually
+   * produced — never the original quoted sourceAmount:
+   *  - TREASURY_TRANSFER withdraws the preceding EXCHANGE_CONVERT's realized output.
+   *  - an EXCHANGE_CONVERT that follows a TREASURY_TRANSFER converts what that
+   *    transfer delivered.
+   * The first convert (no preceding transfer) keeps the default sourceAmount: it
+   * converts the deposit that EXCHANGE_SEND moved onto the venue.
+   */
+  private wireAmountSources(steps: FlowSystemStep[]): void {
+    for (let index = 0; index < steps.length; index += 1) {
+      const step = steps[index]
+      if (step.config.amountSource !== undefined) {
+        continue
+      }
+
+      if (step.stepType === FlowStepType.TREASURY_TRANSFER) {
+        const convertOrder = this.findPrecedingStepOrder(steps, index, FlowStepType.EXCHANGE_CONVERT)
+        if (convertOrder !== undefined) {
+          step.config = { ...step.config, amountSource: { field: 'amount', kind: 'step', stepOrder: convertOrder } }
+        }
+      }
+      else if (step.stepType === FlowStepType.EXCHANGE_CONVERT) {
+        const transferOrder = this.findPrecedingStepOrder(steps, index, FlowStepType.TREASURY_TRANSFER)
+        if (transferOrder !== undefined) {
+          step.config = { ...step.config, amountSource: { field: 'amount', kind: 'step', stepOrder: transferOrder } }
+        }
+      }
+    }
   }
 }

--- a/abroad-server/src/modules/flows/application/steps/ExchangeConvertStepExecutor.ts
+++ b/abroad-server/src/modules/flows/application/steps/ExchangeConvertStepExecutor.ts
@@ -41,12 +41,25 @@ type BinanceNotionalFilter = {
   notional?: string
 }
 
+type BinanceOrderFillLite = {
+  commission?: string
+  commissionAsset?: string
+}
+
 type BinanceOrderPayload = {
+  newClientOrderId?: string
   quantity?: number
   quoteOrderQty?: number
   side: 'BUY' | 'SELL'
   symbol: string
   type: 'MARKET'
+}
+
+type BinanceOrderResultLite = {
+  cummulativeQuoteQty?: string
+  executedQty?: string
+  fills?: BinanceOrderFillLite[]
+  orderId?: number
 }
 
 type BinanceSymbolInfo = {
@@ -79,12 +92,16 @@ class BinanceOrderConstraintError extends Error {
 
 const exchangeConvertConfigSchema = z.object({
   amountSource: amountSourceSchema.optional(),
+  fromAsset: z.string().min(2).optional(),
   provider: z.enum(['binance', 'transfero']),
   side: z.enum(['BUY', 'SELL']).optional(),
   sourceCurrency: z.string().min(1).optional(),
   symbol: z.string().min(3).optional(),
   targetCurrency: z.nativeEnum(TargetCurrency).optional(),
+  toAsset: z.string().min(2).optional(),
 })
+
+type ExchangeConvertConfig = z.infer<typeof exchangeConvertConfigSchema>
 
 @injectable()
 export class ExchangeConvertStepExecutor implements FlowStepExecutor {
@@ -151,8 +168,10 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
       }
     }
 
-    if (!config.symbol || !config.side) {
-      return { error: 'Binance conversion requires symbol and side', outcome: 'failed' }
+    const hasPair = Boolean(config.fromAsset && config.toAsset)
+    const hasExplicitSymbol = Boolean(config.symbol && config.side)
+    if (!hasPair && !hasExplicitSymbol) {
+      return { error: 'Binance conversion requires fromAsset/toAsset or symbol/side', outcome: 'failed' }
     }
 
     try {
@@ -168,22 +187,68 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
         baseUrl: apiUrl,
       })
 
-      const { adjustedAmount, orderPayload } = await this.buildBinanceOrderPayload({
+      const market = await this.resolveBinanceMarket({ apiUrl, config })
+      if (!market) {
+        return { error: 'No Binance market found for the requested conversion', outcome: 'failed' }
+      }
+
+      const { orderPayload } = await this.buildBinanceOrderPayload({
         amount,
         apiUrl,
-        side: config.side,
-        symbol: config.symbol,
+        side: market.side,
+        symbol: market.symbol,
+        symbolInfo: market.symbolInfo,
       })
 
-      const order = await client.submitNewOrder(orderPayload)
+      // Idempotency: a deterministic clientOrderId ties this conversion to a
+      // single Binance order across retries. If a prior attempt already placed
+      // the order (we re-submit the same id and Binance rejects the duplicate),
+      // recover that fill instead of submitting a second, doubling order.
+      const clientOrderId = this.buildClientOrderId(runtime.context.transactionId, params.stepOrder)
+      if (clientOrderId) {
+        orderPayload.newClientOrderId = clientOrderId
+      }
+
+      let order: unknown
+      try {
+        order = await client.submitNewOrder(orderPayload)
+      }
+      catch (submitError) {
+        if (clientOrderId && this.isDuplicateOrderError(submitError)) {
+          const existing = await this.fetchFilledOrder(client, market.symbol, clientOrderId)
+          if (!existing) {
+            throw submitError
+          }
+          this.logger.warn('Recovered existing Binance order on duplicate submit', { clientOrderId, symbol: market.symbol })
+          order = existing
+        }
+        else {
+          throw submitError
+        }
+      }
+
+      // Downstream hops must act on the asset actually received, net of trading
+      // commission — never the input amount (which ignores spread + fees).
+      const receivedAmount = this.computeRealizedReceivedAmount({
+        order,
+        side: market.side,
+        symbolInfo: market.symbolInfo,
+      })
+
+      if (receivedAmount === undefined) {
+        // The order executed but we cannot determine the received amount; fail
+        // (operator-retryable). The deterministic clientOrderId makes the retry
+        // idempotent — it recovers the existing fill rather than re-submitting.
+        return { error: 'Binance conversion filled but realized amount is undeterminable', outcome: 'failed' }
+      }
 
       return {
         outcome: 'succeeded',
         output: {
-          amount: adjustedAmount,
-          orderId: order?.orderId ?? null,
+          amount: receivedAmount,
+          orderId: (order as BinanceOrderResultLite)?.orderId ?? null,
           provider: 'binance',
-          symbol: config.symbol,
+          symbol: market.symbol,
         },
       }
     }
@@ -196,21 +261,11 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
         return { error: error.message, outcome: 'failed' }
       }
 
+      // Convert errors are terminal-but-operator-retryable: there is no signal
+      // that resumes a WAITING EXCHANGE_CONVERT (the balance-update channel only
+      // wakes AWAIT_EXCHANGE_BALANCE steps), so a 'waiting' convert would strand
+      // forever. Recovery is an explicit ops retry, which re-runs execute().
       const message = error instanceof Error ? error.message : 'binance_convert_error'
-      const normalized = message.toLowerCase()
-      const isRetryable = normalized.includes('insufficient') || normalized.includes('balance')
-      if (isRetryable) {
-        return {
-          correlation: { provider: 'binance' },
-          outcome: 'waiting',
-          output: {
-            amount,
-            provider: 'binance',
-            retryReason: message,
-            symbol: config.symbol,
-          },
-        }
-      }
       this.logger.error('Binance conversion failed', error)
       return { error: message, outcome: 'failed' }
     }
@@ -221,17 +276,20 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
     apiUrl: string
     side: 'BUY' | 'SELL'
     symbol: string
+    symbolInfo?: BinanceSymbolInfo
   }): Promise<{ adjustedAmount: number, orderPayload: BinanceOrderPayload }> {
     const { amount, apiUrl, side, symbol } = params
-    let symbolInfo: BinanceSymbolInfo | undefined
-    try {
-      symbolInfo = await this.getSymbolInfo(symbol, apiUrl)
-    }
-    catch (error) {
-      this.logger.warn('Unable to load Binance exchange info; proceeding without filters', {
-        error,
-        symbol,
-      })
+    let symbolInfo: BinanceSymbolInfo | undefined = params.symbolInfo
+    if (!symbolInfo) {
+      try {
+        symbolInfo = await this.getSymbolInfo(symbol, apiUrl)
+      }
+      catch (error) {
+        this.logger.warn('Unable to load Binance exchange info; proceeding without filters', {
+          error,
+          symbol,
+        })
+      }
     }
 
     if (!symbolInfo) {
@@ -320,11 +378,135 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
     return `${trimmed}${path}`
   }
 
+  /**
+   * Deterministic Binance clientOrderId for a conversion: stable across retries
+   * of the same flow step so re-running it maps to the SAME order (Binance
+   * rejects a duplicate clientOrderId). Alphanumeric only, capped at 36 chars
+   * per Binance's clientOrderId limit. Undefined if no transaction id is known.
+   */
+  private buildClientOrderId(transactionId: string | undefined, stepOrder: number): string | undefined {
+    if (!transactionId) {
+      return undefined
+    }
+    const compact = transactionId.replace(/[^a-zA-Z0-9]/g, '')
+    return `${compact}${stepOrder}`.slice(0, 36)
+  }
+
+  /**
+   * The amount of the RECEIVED asset actually credited by a filled market order,
+   * net of trading commission charged in that asset. For BUY the received asset
+   * is the base (executedQty); for SELL it is the quote (cummulativeQuoteQty).
+   * Falls back to the order's input amount if the fill payload is unavailable.
+   */
+  private computeRealizedReceivedAmount(params: {
+    order: unknown
+    side: 'BUY' | 'SELL'
+    symbolInfo: BinanceSymbolInfo
+  }): number | undefined {
+    const { order, side, symbolInfo } = params
+    const result = order as BinanceOrderResultLite
+    const receivedAsset = (side === 'BUY' ? symbolInfo.baseAsset : symbolInfo.quoteAsset)?.toUpperCase()
+    // Received asset = base on BUY (executedQty), quote on SELL (cummulativeQuoteQty).
+    // If it cannot be read we return undefined — NEVER the input amount, which is
+    // a different asset's denomination and would misdirect the downstream hop.
+    const gross = Number(side === 'BUY' ? result?.executedQty : result?.cummulativeQuoteQty)
+    if (!Number.isFinite(gross) || gross <= 0) {
+      return undefined
+    }
+
+    let commission = 0
+    const fills = Array.isArray(result?.fills) ? result.fills : []
+    for (const fill of fills) {
+      if (typeof fill?.commissionAsset === 'string' && fill.commissionAsset.toUpperCase() === receivedAsset) {
+        const value = Number(fill.commission)
+        if (Number.isFinite(value)) {
+          commission += value
+        }
+      }
+    }
+
+    const net = gross - commission
+    if (net <= 0) {
+      return undefined
+    }
+    // Floor (never round up) to the received asset's precision: this value is
+    // used verbatim as the next hop's withdraw/convert amount, so a float tail
+    // must never push it above the balance actually held.
+    const rawPrecision = side === 'BUY' ? symbolInfo.baseAssetPrecision : symbolInfo.quoteAssetPrecision
+    const precision = typeof rawPrecision === 'number' ? Math.max(0, Math.min(rawPrecision, 8)) : 8
+    const scale = 10 ** precision
+    const floored = Math.floor(net * scale) / scale
+    return floored > 0 ? floored : undefined
+  }
+
   private decimalsFromStep(stepSize: string): number {
     const trimmed = stepSize.trim()
     const dot = trimmed.indexOf('.')
     if (dot < 0) return 0
     return trimmed.slice(dot + 1).replace(/0+$/, '').length
+  }
+
+  /**
+   * Normalise a Binance error across the two shapes we see: the `binance`
+   * client throws a PLAIN OBJECT { code, message, body }, while the raw axios
+   * calls (exchangeInfo/bookTicker) throw an AxiosError with response.data.
+   * Returns the numeric code and a lowercased, concatenated message text.
+   */
+  private describeBinanceError(error: unknown): { code: number | undefined, text: string } {
+    const e = error as {
+      body?: { code?: number, msg?: string }
+      code?: number
+      message?: string
+      response?: { data?: { code?: number, msg?: string } }
+    }
+    const code = e?.code ?? e?.body?.code ?? e?.response?.data?.code
+    const parts = [e?.message, e?.body?.msg, e?.response?.data?.msg, error instanceof Error ? error.message : undefined]
+      .filter((part): part is string => typeof part === 'string')
+    return { code, text: parts.join(' | ').toLowerCase() }
+  }
+
+  /**
+   * Fetch a previously-placed order by clientOrderId and, if filled, shape it
+   * (with trade commissions) like a fresh order result so the realized amount
+   * can be computed. Used to recover idempotently from a duplicate-order submit.
+   */
+  private async fetchFilledOrder(client: MainClient, symbol: string, clientOrderId: string): Promise<BinanceOrderResultLite | undefined> {
+    try {
+      const order = await client.getOrder({ origClientOrderId: clientOrderId, symbol }) as {
+        cummulativeQuoteQty?: string
+        executedQty?: string
+        orderId?: number
+        status?: string
+      }
+      // Only a terminal, fully-FILLED order is safe to treat as the final
+      // realized amount. A non-terminal PARTIALLY_FILLED order is not settled,
+      // so we surface it as unresolved (retryable) rather than under-deliver.
+      if (order?.status !== 'FILLED' || typeof order.orderId !== 'number') {
+        return undefined
+      }
+
+      // Trades are REQUIRED to know the commission: without them we'd return the
+      // gross and over-report the received amount, driving an oversized withdraw.
+      // If the trade lookup fails it bubbles to the catch below → undefined.
+      const trades = await client.getAccountTradeList({ orderId: order.orderId, symbol })
+      if (!Array.isArray(trades) || trades.length === 0) {
+        return undefined
+      }
+
+      return {
+        cummulativeQuoteQty: order.cummulativeQuoteQty,
+        executedQty: order.executedQty,
+        fills: trades.map(trade => ({
+          commission: (trade as { commission?: string })?.commission,
+          commissionAsset: (trade as { commissionAsset?: string })?.commissionAsset,
+        })),
+        orderId: order.orderId,
+      }
+    }
+    catch (error) {
+      this.logger.warn('Unable to fetch existing Binance order on duplicate submit', { clientOrderId, error, symbol })
+      return undefined
+    }
   }
 
   private floorToStep(amount: number, stepSize: string): number {
@@ -378,10 +560,74 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
     return info
   }
 
+  /** Binance "Duplicate order sent." rejection (same clientOrderId re-submitted). */
+  private isDuplicateOrderError(error: unknown): boolean {
+    return this.describeBinanceError(error).text.includes('duplicate order')
+  }
+
+  /**
+   * A DEFINITIVE "symbol not listed" — Binance code -1121, an "Invalid symbol"
+   * message, or an empty exchangeInfo result. A bare HTTP 400 (e.g. a proxy/WAF
+   * rejection) is NOT treated as not-listed: it propagates so the conversion
+   * fails (operator-retryable) instead of being silently skipped as if the pair
+   * did not exist.
+   */
+  private isSymbolNotListedError(error: unknown): boolean {
+    const { code, text } = this.describeBinanceError(error)
+    return code === -1121
+      || text.includes('invalid symbol')
+      || text.includes('exchangeinfo missing for symbol')
+  }
+
   private parseNumber(value: string | undefined): number | undefined {
     if (!value) return undefined
     const parsed = Number(value)
     return Number.isFinite(parsed) ? parsed : undefined
+  }
+
+  /**
+   * Resolve the Binance trading symbol + order side for a conversion.
+   * Binance lists each pair in a single direction, so a from/to intent must be
+   * probed in both orientations against exchangeInfo: if `from+to` is a real
+   * symbol the base is `from` (SELL base for quote); if `to+from` is real the
+   * base is `to` (BUY base, spending `from` as the quote). An explicit
+   * symbol/side is honoured but still verified — we never submit an order for a
+   * symbol Binance does not list.
+   */
+  private async resolveBinanceMarket(params: {
+    apiUrl: string
+    config: ExchangeConvertConfig
+  }): Promise<undefined | { side: 'BUY' | 'SELL', symbol: string, symbolInfo: BinanceSymbolInfo }> {
+    const { apiUrl, config } = params
+    const candidates: { expectBase?: string, expectQuote?: string, side: 'BUY' | 'SELL', symbol: string }[] = []
+
+    if (config.fromAsset && config.toAsset) {
+      const from = config.fromAsset.toUpperCase()
+      const to = config.toAsset.toUpperCase()
+      candidates.push({ expectBase: from, expectQuote: to, side: 'SELL', symbol: `${from}${to}` })
+      candidates.push({ expectBase: to, expectQuote: from, side: 'BUY', symbol: `${to}${from}` })
+    }
+    else if (config.symbol && config.side) {
+      candidates.push({ side: config.side, symbol: config.symbol.toUpperCase() })
+    }
+
+    for (const candidate of candidates) {
+      const symbolInfo = await this.tryGetSymbolInfo(candidate.symbol, apiUrl)
+      if (!symbolInfo) {
+        continue
+      }
+      // Existence alone is insufficient: confirm the listed base/quote match the
+      // intent so a concatenation collision can never drive a wrong-side order.
+      if (candidate.expectBase !== undefined) {
+        const base = symbolInfo.baseAsset?.toUpperCase()
+        const quote = symbolInfo.quoteAsset?.toUpperCase()
+        if (base !== candidate.expectBase || quote !== candidate.expectQuote) {
+          continue
+        }
+      }
+      return { side: candidate.side, symbol: candidate.symbol, symbolInfo }
+    }
+    return undefined
   }
 
   private roundToPrecision(amount: number, decimals: number): number {
@@ -389,5 +635,20 @@ export class ExchangeConvertStepExecutor implements FlowStepExecutor {
     if (normalizedDecimals === 0) return Math.trunc(amount)
     // Convert through string to clamp floating point tails (e.g., 1.1000000003).
     return Number(amount.toFixed(normalizedDecimals))
+  }
+
+  private async tryGetSymbolInfo(symbol: string, apiUrl: string): Promise<BinanceSymbolInfo | undefined> {
+    try {
+      return await this.getSymbolInfo(symbol, apiUrl)
+    }
+    catch (error) {
+      // Only swallow a definitive "symbol not listed" so we can probe the other
+      // orientation. Transient errors (timeout/5xx/rate-limit) must propagate so
+      // a funded conversion is retried, not stranded on a doomed assumption.
+      if (this.isSymbolNotListedError(error)) {
+        return undefined
+      }
+      throw error
+    }
   }
 }

--- a/abroad-server/src/modules/flows/application/steps/TreasuryTransferStepExecutor.ts
+++ b/abroad-server/src/modules/flows/application/steps/TreasuryTransferStepExecutor.ts
@@ -1,5 +1,5 @@
 import { Wallet } from '@binance/wallet'
-import { FlowStepType, TargetCurrency } from '@prisma/client'
+import { CryptoCurrency, FlowStepType, TargetCurrency } from '@prisma/client'
 import { inject, injectable } from 'inversify'
 import { z } from 'zod'
 
@@ -8,6 +8,7 @@ import { createScopedLogger, ScopedLogger } from '../../../../core/logging/scope
 import { ILogger } from '../../../../core/logging/types'
 import { ISecretManager, Secrets } from '../../../../platform/secrets/ISecretManager'
 import { IExchangeProviderFactory } from '../../../treasury/application/contracts/IExchangeProviderFactory'
+import { mapBlockchainToBinanceNetwork } from '../../../treasury/infrastructure/exchangeProviders/binanceNetworkMap'
 import { AmountSource, amountSourceSchema, resolveAmount } from '../flowAmountResolver'
 import { FlowStepExecutionResult, FlowStepExecutor, FlowStepRuntimeContext } from '../flowTypes'
 
@@ -60,9 +61,26 @@ export class TreasuryTransferStepExecutor implements FlowStepExecutor {
     try {
       const destinationCurrency = config.destinationTargetCurrency ?? this.resolveProviderCurrency(config.destinationProvider)
       const destinationProvider = this.exchangeProviderFactory.getExchangeProvider(destinationCurrency)
+
+      // The bridge chain is a property of the destination provider + the asset
+      // being moved (e.g. Transfero accepts USDC on Solana) — NOT the original
+      // deposit chain (runtime.context.blockchain is the source USDT/CELO leg).
+      // Resolve it ONCE and derive BOTH the deposit address and the Binance
+      // withdraw network from it, so they can never refer to different chains
+      // and route funds to the wrong network.
+      const asset = config.asset as CryptoCurrency
+      const bridgeNetwork = destinationProvider.getDepositNetwork?.({ cryptoCurrency: asset })
+      if (!bridgeNetwork) {
+        return { error: `No destination deposit network for ${config.asset}`, outcome: 'failed' }
+      }
+      const withdrawNetwork = mapBlockchainToBinanceNetwork(bridgeNetwork)
+      if (!withdrawNetwork) {
+        return { error: `Unsupported withdraw network for ${bridgeNetwork}`, outcome: 'failed' }
+      }
+
       const addressResult = await destinationProvider.getExchangeAddress({
-        blockchain: runtime.context.blockchain,
-        cryptoCurrency: runtime.context.cryptoCurrency,
+        blockchain: bridgeNetwork,
+        cryptoCurrency: asset,
       })
 
       if (!addressResult.success) {
@@ -85,18 +103,18 @@ export class TreasuryTransferStepExecutor implements FlowStepExecutor {
 
       const response = await client.restAPI.withdraw({
         address: addressResult.address,
-        addressTag: addressResult.memo,
+        addressTag: addressResult.memo ?? undefined,
         amount,
         coin: config.asset,
-        network: config.network,
+        network: withdrawNetwork,
       })
 
       const data = await response.data()
 
       // Report the amount that will ARRIVE at the destination (withdrawn − the
-      // network withdrawal fee) so the next hop converts what was actually
-      // credited, not the gross withdrawal. Falls back to gross if unknown.
-      const withdrawalFee = await this.resolveWithdrawalFee(client, config.asset, config.network)
+      // network withdrawal fee on the SAME bridge network) so the next hop
+      // converts what was actually credited. Falls back to gross if unknown.
+      const withdrawalFee = await this.resolveWithdrawalFee(client, config.asset, withdrawNetwork)
       const creditedAmount = withdrawalFee !== undefined ? Math.max(0, amount - withdrawalFee) : amount
 
       return {

--- a/abroad-server/src/modules/flows/application/steps/TreasuryTransferStepExecutor.ts
+++ b/abroad-server/src/modules/flows/application/steps/TreasuryTransferStepExecutor.ts
@@ -93,12 +93,19 @@ export class TreasuryTransferStepExecutor implements FlowStepExecutor {
 
       const data = await response.data()
 
+      // Report the amount that will ARRIVE at the destination (withdrawn − the
+      // network withdrawal fee) so the next hop converts what was actually
+      // credited, not the gross withdrawal. Falls back to gross if unknown.
+      const withdrawalFee = await this.resolveWithdrawalFee(client, config.asset, config.network)
+      const creditedAmount = withdrawalFee !== undefined ? Math.max(0, amount - withdrawalFee) : amount
+
       return {
         outcome: 'succeeded',
         output: {
           address: addressResult.address,
-          amount,
+          amount: creditedAmount,
           destinationProvider: config.destinationProvider,
+          grossAmount: amount,
           memo: addressResult.memo ?? null,
           withdrawId: data?.id ?? null,
         },
@@ -114,5 +121,29 @@ export class TreasuryTransferStepExecutor implements FlowStepExecutor {
   private resolveProviderCurrency(provider: TreasuryTransferConfig['destinationProvider']): TargetCurrency {
     if (provider === 'binance') return TargetCurrency.COP
     return TargetCurrency.BRL
+  }
+
+  /**
+   * The Binance withdrawal network fee for a coin/network (deducted from the
+   * withdrawal, so the recipient receives amount − fee). Best-effort: returns
+   * undefined on any failure so the caller falls back to the gross amount.
+   */
+  private async resolveWithdrawalFee(client: Wallet, coin: string, network: string | undefined): Promise<number | undefined> {
+    try {
+      const response = await client.restAPI.allCoinsInformation()
+      const data = await response.data()
+      const coins = Array.isArray(data) ? data : []
+      const match = coins.find(entry => typeof entry?.coin === 'string' && entry.coin.toUpperCase() === coin.toUpperCase())
+      const networks = Array.isArray(match?.networkList) ? match.networkList : []
+      const networkEntry = network
+        ? networks.find(item => item?.network === network)
+        : networks.find(item => item?.isDefault) ?? networks[0]
+      const fee = Number(networkEntry?.withdrawFee)
+      return Number.isFinite(fee) && fee >= 0 ? fee : undefined
+    }
+    catch (error) {
+      this.logger.warn('Unable to resolve Binance withdrawal fee; using gross amount', { coin, error, network })
+      return undefined
+    }
   }
 }

--- a/abroad-server/src/modules/treasury/application/contracts/IExchangeProvider.ts
+++ b/abroad-server/src/modules/treasury/application/contracts/IExchangeProvider.ts
@@ -24,6 +24,15 @@ export interface IExchangeProvider {
   }): Promise<ExchangeOperationResult>
   readonly exchangePercentageFee: number
 
+  /**
+   * The blockchain this provider accepts deposits of `cryptoCurrency` on (e.g.
+   * Transfero accepts USDC on Solana). Lets a treasury transfer derive BOTH the
+   * destination deposit address and the source-venue withdraw network from one
+   * authoritative value, so funds can never be sent to a mismatched chain.
+   * Returns undefined when the provider has no deposit chain for the asset.
+   */
+  getDepositNetwork?(params: { cryptoCurrency: CryptoCurrency }): BlockchainNetwork | undefined
+
   getExchangeAddress(params: {
     blockchain: BlockchainNetwork
     cryptoCurrency: CryptoCurrency

--- a/abroad-server/src/modules/treasury/infrastructure/exchangeProviders/binanceExchangeProvider.ts
+++ b/abroad-server/src/modules/treasury/infrastructure/exchangeProviders/binanceExchangeProvider.ts
@@ -17,6 +17,7 @@ import {
   ExchangeProviderCapability,
   IExchangeProvider,
 } from '../../application/contracts/IExchangeProvider'
+import { mapBlockchainToBinanceNetwork } from './binanceNetworkMap'
 
 type BinanceBookTickerResponse = {
   askPrice: string
@@ -207,16 +208,11 @@ export class BinanceExchangeProvider implements IExchangeProvider {
    * @returns The corresponding Binance network name
    */
   private mapBlockchainToNetwork(blockchain: BlockchainNetwork): string {
-    switch (blockchain) {
-      case BlockchainNetwork.CELO:
-        return 'CELO'
-      case BlockchainNetwork.SOLANA:
-        return 'SOL'
-      case BlockchainNetwork.STELLAR:
-        return 'XLM'
-      default:
-        throw new Error(`Unsupported blockchain: ${blockchain}`)
+    const network = mapBlockchainToBinanceNetwork(blockchain)
+    if (!network) {
+      throw new Error(`Unsupported blockchain: ${blockchain}`)
     }
+    return network
   }
 }
 

--- a/abroad-server/src/modules/treasury/infrastructure/exchangeProviders/binanceNetworkMap.ts
+++ b/abroad-server/src/modules/treasury/infrastructure/exchangeProviders/binanceNetworkMap.ts
@@ -1,0 +1,20 @@
+import { BlockchainNetwork } from '@prisma/client'
+
+/**
+ * Binance network token for a blockchain, used for BOTH deposit-address lookup
+ * and withdrawals so the two can never refer to different chains. Returns
+ * undefined for unsupported chains so callers fail deterministically instead of
+ * letting Binance default-route a withdrawal to the wrong network.
+ */
+export function mapBlockchainToBinanceNetwork(blockchain: BlockchainNetwork): string | undefined {
+  switch (blockchain) {
+    case BlockchainNetwork.CELO:
+      return 'CELO'
+    case BlockchainNetwork.SOLANA:
+      return 'SOL'
+    case BlockchainNetwork.STELLAR:
+      return 'XLM'
+    default:
+      return undefined
+  }
+}

--- a/abroad-server/src/modules/treasury/infrastructure/exchangeProviders/transferoExchangeProvider.ts
+++ b/abroad-server/src/modules/treasury/infrastructure/exchangeProviders/transferoExchangeProvider.ts
@@ -86,6 +86,22 @@ export class TransferoExchangeProvider implements IExchangeProvider {
            * Retrieves (or creates) the deposit wallet for the partner account.
            * Falls back to the first wallet that matches both currency and chain.
            */
+  /**
+   * Transfero accepts stablecoin deposits (USDC/USDT) on Solana — its USDC
+   * deposit wallet is the Solana TRANSFERO_SOLANA_WALLET. Used by treasury
+   * transfers to pin both the deposit address and the source-venue withdraw
+   * network to Solana so USDC cannot be bridged on the wrong chain.
+   */
+  getDepositNetwork: NonNullable<IExchangeProvider['getDepositNetwork']> = ({ cryptoCurrency }) => {
+    switch (cryptoCurrency) {
+      case CryptoCurrency.USDC:
+      case CryptoCurrency.USDT:
+        return BlockchainNetwork.SOLANA
+      default:
+        return undefined
+    }
+  }
+
   getExchangeAddress: IExchangeProvider['getExchangeAddress'] = async ({
     blockchain,
   }): Promise<ExchangeAddressResult> => {

--- a/abroad-server/src/tests/modules/flows/application/FlowDefinitionBuilder.test.ts
+++ b/abroad-server/src/tests/modules/flows/application/FlowDefinitionBuilder.test.ts
@@ -1,0 +1,122 @@
+import {
+  BlockchainNetwork,
+  CryptoCurrency,
+  FlowPricingProvider,
+  FlowStepType,
+  PaymentMethod,
+  SupportedCurrency,
+  TargetCurrency,
+} from '@prisma/client'
+
+import { FlowDefinitionBuilder } from '../../../../modules/flows/application/FlowDefinitionBuilder'
+
+describe('FlowDefinitionBuilder Binance convert', () => {
+  const makeBuilder = (isAsync = false) => {
+    const paymentService = { isAsync }
+    const paymentServiceFactory = {
+      getPaymentService: jest.fn(() => paymentService),
+      getPaymentServiceForCapability: jest.fn(() => paymentService),
+    }
+    return new FlowDefinitionBuilder(paymentServiceFactory as never)
+  }
+
+  const multiHopSteps = () => ([
+    { type: 'PAYOUT' as const },
+    { type: 'MOVE_TO_EXCHANGE' as const, venue: 'BINANCE' as const },
+    { fromAsset: SupportedCurrency.USDT, toAsset: SupportedCurrency.USDC, type: 'CONVERT' as const, venue: 'BINANCE' as const },
+    { asset: SupportedCurrency.USDC, fromVenue: 'BINANCE' as const, toVenue: 'TRANSFERO' as const, type: 'TRANSFER_VENUE' as const },
+    { fromAsset: SupportedCurrency.USDC, toAsset: SupportedCurrency.BRL, type: 'CONVERT' as const, venue: 'TRANSFERO' as const },
+  ])
+
+  // Binance lists each pair in ONE direction only (e.g. USDCUSDT, never USDTUSDC).
+  // The builder must not guess the symbol/side by string concatenation; it must
+  // emit the conversion intent (fromAsset/toAsset) and let the executor resolve
+  // the venue-specific symbol + side against live exchangeInfo.
+  it('emits fromAsset/toAsset intent for a Binance convert instead of a guessed symbol/side', () => {
+    const builder = makeBuilder()
+
+    const steps = builder.build({
+      blockchain: BlockchainNetwork.CELO,
+      cryptoCurrency: CryptoCurrency.USDT,
+      name: 'usdt-celo-brl',
+      payoutProvider: PaymentMethod.PIX,
+      pricingProvider: FlowPricingProvider.BINANCE,
+      steps: [
+        { type: 'PAYOUT' },
+        { type: 'MOVE_TO_EXCHANGE', venue: 'BINANCE' },
+        { fromAsset: SupportedCurrency.USDT, toAsset: SupportedCurrency.USDC, type: 'CONVERT', venue: 'BINANCE' },
+      ],
+      targetCurrency: TargetCurrency.BRL,
+    })
+
+    const convert = steps.find(step => step.stepType === FlowStepType.EXCHANGE_CONVERT)
+    expect(convert?.config).toMatchObject({ fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' })
+    expect(convert?.config).not.toHaveProperty('symbol')
+    expect(convert?.config).not.toHaveProperty('side')
+  })
+
+  // Multi-hop must propagate the REALIZED amount between money-moving hops:
+  // the post-convert TREASURY_TRANSFER must withdraw what the convert produced,
+  // and the final Transfero convert must convert what the transfer delivered —
+  // never the original quoted sourceAmount (which ignores spread + fees).
+  it('wires amountSource so each hop consumes the prior step realized output', () => {
+    const builder = makeBuilder()
+
+    const steps = builder.build({
+      blockchain: BlockchainNetwork.CELO,
+      cryptoCurrency: CryptoCurrency.USDT,
+      name: 'usdt-celo-brl-multihop',
+      payoutProvider: PaymentMethod.PIX,
+      pricingProvider: FlowPricingProvider.BINANCE,
+      steps: [
+        { type: 'PAYOUT' },
+        { type: 'MOVE_TO_EXCHANGE', venue: 'BINANCE' },
+        { fromAsset: SupportedCurrency.USDT, toAsset: SupportedCurrency.USDC, type: 'CONVERT', venue: 'BINANCE' },
+        { asset: SupportedCurrency.USDC, fromVenue: 'BINANCE', toVenue: 'TRANSFERO', type: 'TRANSFER_VENUE' },
+        { fromAsset: SupportedCurrency.USDC, toAsset: SupportedCurrency.BRL, type: 'CONVERT', venue: 'TRANSFERO' },
+      ],
+      targetCurrency: TargetCurrency.BRL,
+    })
+
+    const binanceConvert = steps.find(s => s.stepType === FlowStepType.EXCHANGE_CONVERT && s.config.provider === 'binance')
+    const transfer = steps.find(s => s.stepType === FlowStepType.TREASURY_TRANSFER)
+    const transferoConvert = steps.find(s => s.stepType === FlowStepType.EXCHANGE_CONVERT && s.config.provider === 'transfero')
+
+    // First (Binance) convert converts the deposited amount — no upstream wiring.
+    expect(binanceConvert?.config).not.toHaveProperty('amountSource')
+
+    // Transfer withdraws exactly the Binance convert's realized output.
+    expect(transfer?.config.amountSource).toEqual({ field: 'amount', kind: 'step', stepOrder: binanceConvert?.stepOrder })
+
+    // Final Transfero convert converts exactly what the transfer delivered.
+    expect(transferoConvert?.config.amountSource).toEqual({ field: 'amount', kind: 'step', stepOrder: transfer?.stepOrder })
+  })
+
+  // An async payout inserts AWAIT_PROVIDER_STATUS, shifting every later step's
+  // absolute order. The wiring uses absolute orders, so it must follow the shift.
+  it('wires amountSource to shifted absolute orders when the payout is async', () => {
+    const builder = makeBuilder(true)
+
+    const steps = builder.build({
+      blockchain: BlockchainNetwork.CELO,
+      cryptoCurrency: CryptoCurrency.USDT,
+      name: 'usdt-celo-brl-async',
+      payoutProvider: PaymentMethod.PIX,
+      pricingProvider: FlowPricingProvider.BINANCE,
+      steps: multiHopSteps(),
+      targetCurrency: TargetCurrency.BRL,
+    })
+
+    expect(steps.find(s => s.stepType === FlowStepType.AWAIT_PROVIDER_STATUS)?.stepOrder).toBe(2)
+
+    const binanceConvert = steps.find(s => s.stepType === FlowStepType.EXCHANGE_CONVERT && s.config.provider === 'binance')
+    const transfer = steps.find(s => s.stepType === FlowStepType.TREASURY_TRANSFER)
+    const transferoConvert = steps.find(s => s.stepType === FlowStepType.EXCHANGE_CONVERT && s.config.provider === 'transfero')
+
+    expect(transfer?.config.amountSource).toEqual({ field: 'amount', kind: 'step', stepOrder: binanceConvert?.stepOrder })
+    expect(transferoConvert?.config.amountSource).toEqual({ field: 'amount', kind: 'step', stepOrder: transfer?.stepOrder })
+    // Sanity: the shift really happened (orders are not the sync-case values).
+    expect(binanceConvert?.stepOrder).toBe(5)
+    expect(transfer?.stepOrder).toBe(6)
+  })
+})

--- a/abroad-server/src/tests/modules/flows/application/steps/ExchangeConvertStepExecutor.test.ts
+++ b/abroad-server/src/tests/modules/flows/application/steps/ExchangeConvertStepExecutor.test.ts
@@ -1,0 +1,333 @@
+import axios from 'axios'
+import { MainClient } from 'binance'
+
+import { ExchangeConvertStepExecutor } from '../../../../../modules/flows/application/steps/ExchangeConvertStepExecutor'
+
+jest.mock('axios', () => ({ get: jest.fn() }))
+const submitNewOrderMock = jest.fn()
+const getOrderMock = jest.fn()
+const getAccountTradeListMock = jest.fn()
+jest.mock('binance', () => ({
+  MainClient: jest.fn().mockImplementation(() => ({
+    getAccountTradeList: getAccountTradeListMock,
+    getOrder: getOrderMock,
+    submitNewOrder: submitNewOrderMock,
+  })),
+}))
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+const MockedMainClient = MainClient as unknown as jest.Mock
+
+const USDCUSDT_INFO = {
+  baseAsset: 'USDC',
+  filters: [
+    { filterType: 'LOT_SIZE', maxQty: '900000', minQty: '1.00000000', stepSize: '1.00000000' },
+    { filterType: 'NOTIONAL', minNotional: '5.00000000' },
+  ],
+  quoteAsset: 'USDT',
+  quoteAssetPrecision: 8,
+  symbol: 'USDCUSDT',
+}
+
+const baseLogger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() }
+
+const makeExecutor = () => {
+  const secretManager = {
+    getSecret: jest.fn(async (name: string) => {
+      if (name.includes('URL')) return 'http://proxy.local'
+      return `secret-${name}`
+    }),
+    getSecrets: jest.fn(async () => ({})),
+  }
+  const exchangeProviderFactory = {
+    getExchangeProvider: jest.fn(),
+    getExchangeProviderForCapability: jest.fn(),
+  }
+  const executor = new ExchangeConvertStepExecutor(
+    exchangeProviderFactory as never,
+    secretManager as never,
+    baseLogger as never,
+  )
+  return { executor }
+}
+
+// exchangeInfo answers ONLY for the symbols passed in `valid`; everything else
+// rejects with a Binance 400 (mirrors real "Invalid symbol" / code -1121).
+const mockExchange = (valid: Record<string, typeof USDCUSDT_INFO>) => {
+  mockedAxios.get.mockImplementation((async (url: string, opts?: { params?: { symbol?: string } }) => {
+    const symbol = opts?.params?.symbol ?? ''
+    if (url.includes('/exchangeInfo')) {
+      if (valid[symbol]) return { data: { symbols: [valid[symbol]] } }
+      const err = new Error('Request failed with status code 400') as Error & { response?: unknown }
+      err.response = { data: { code: -1121, msg: 'Invalid symbol.' }, status: 400 }
+      throw err
+    }
+    if (url.includes('/ticker/bookTicker')) {
+      return { data: { askPrice: '1.00065000', bidPrice: '1.00064000', symbol } }
+    }
+    throw new Error(`unexpected axios call: ${url}`)
+  }) as never)
+}
+
+describe('ExchangeConvertStepExecutor Binance market resolution', () => {
+  beforeEach(() => {
+    submitNewOrderMock.mockReset()
+    submitNewOrderMock.mockResolvedValue({ cummulativeQuoteQty: '100.62', executedQty: '100.46', fills: [], orderId: 42 })
+    getOrderMock.mockReset()
+    getAccountTradeListMock.mockReset()
+    mockedAxios.get.mockReset()
+    MockedMainClient.mockClear()
+  })
+
+  // The pair lists as USDCUSDT (USDC base). To turn 100.62 USDT into USDC we must
+  // BUY USDCUSDT, spending USDT via quoteOrderQty — NOT sell a non-existent USDTUSDC.
+  it('resolves USDT->USDC to a BUY on USDCUSDT spending USDT (quoteOrderQty)', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(submitNewOrderMock).toHaveBeenCalledTimes(1)
+    expect(submitNewOrderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteOrderQty: 100.62, side: 'BUY', symbol: 'USDCUSDT', type: 'MARKET' }),
+    )
+  })
+
+  // Reverse direction uses the same pair in its native orientation: SELL USDCUSDT.
+  it('resolves USDC->USDT to a SELL on USDCUSDT (quantity in base asset)', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDC', provider: 'binance', toAsset: 'USDT' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(submitNewOrderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ side: 'SELL', symbol: 'USDCUSDT', type: 'MARKET' }),
+    )
+    const payload = submitNewOrderMock.mock.calls[0][0]
+    expect(payload.quantity).toBe(100) // floored to integer LOT_SIZE step
+    expect(payload.quoteOrderQty).toBeUndefined()
+  })
+
+  it('honors an explicit symbol/side when the symbol is valid', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+
+    const result = await executor.execute({
+      config: { provider: 'binance', side: 'BUY', symbol: 'USDCUSDT' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(submitNewOrderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ side: 'BUY', symbol: 'USDCUSDT' }),
+    )
+  })
+
+  // Never submit a doomed order for a pair that does not exist in either direction.
+  it('fails without submitting an order when no Binance market exists for the pair', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO }) // neither USDCBRL nor BRLUSDC is valid
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDC', provider: 'binance', toAsset: 'BRL' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('failed')
+    expect(submitNewOrderMock).not.toHaveBeenCalled()
+  })
+
+  // The realized RECEIVED amount (net of commission) must be output so the next
+  // hop transfers/converts what was actually produced, not the quoted input.
+  it('outputs the realized base amount received (net of commission) for a BUY', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+    submitNewOrderMock.mockResolvedValue({
+      cummulativeQuoteQty: '100.62',
+      executedQty: '100.46',
+      fills: [{ commission: '0.10', commissionAsset: 'USDC' }],
+      orderId: 7,
+    })
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(result.output?.amount).toBeCloseTo(100.36, 6) // 100.46 received USDC − 0.10 USDC commission
+  })
+
+  it('outputs the realized quote amount received (net of commission) for a SELL', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+    submitNewOrderMock.mockResolvedValue({
+      cummulativeQuoteQty: '100.06',
+      executedQty: '100',
+      fills: [{ commission: '0.05', commissionAsset: 'USDT' }],
+      orderId: 8,
+    })
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDC', provider: 'binance', toAsset: 'USDT' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(result.output?.amount).toBeCloseTo(100.01, 6) // 100.06 received USDT − 0.05 USDT commission
+  })
+
+  // A transient exchangeInfo error (timeout/5xx) on a candidate must NOT be
+  // mistaken for "symbol not listed": it fails terminally WITHOUT submitting an
+  // order (no order placed ⇒ an explicit ops retry is the safe recovery, and
+  // there is no un-resumable 'waiting' convert that strands forever).
+  it('fails terminally without submitting an order on a transient exchangeInfo error', async () => {
+    const { executor } = makeExecutor()
+    mockedAxios.get.mockImplementation((async (url: string, opts?: { params?: { symbol?: string } }) => {
+      const symbol = opts?.params?.symbol ?? ''
+      if (url.includes('/exchangeInfo')) {
+        if (symbol === 'USDCUSDT') {
+          const err = new Error('Request failed with status code 503') as Error & { response?: { status: number } }
+          err.response = { status: 503 }
+          throw err
+        }
+        const notListed = new Error('Request failed with status code 400') as Error & { response?: unknown }
+        notListed.response = { data: { code: -1121, msg: 'Invalid symbol.' }, status: 400 }
+        throw notListed // USDTUSDC: genuinely not listed
+      }
+      throw new Error(`unexpected axios call: ${url}`)
+    }) as never)
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('failed')
+    expect(submitNewOrderMock).not.toHaveBeenCalled()
+  })
+
+  // Existence alone is not enough: a listed symbol whose base/quote do not match
+  // the from/to intent must be rejected (guards against concatenation collisions).
+  it('rejects a listed symbol whose base/quote do not match the intent', async () => {
+    const { executor } = makeExecutor()
+    // 'AAABBB' is listed but decomposes to base=AAAB/quote=BB, not AAA/BBB.
+    mockExchange({ AAABBB: { ...USDCUSDT_INFO, baseAsset: 'AAAB', quoteAsset: 'BB', symbol: 'AAABBB' } })
+
+    const result = await executor.execute({
+      config: { fromAsset: 'AAA', provider: 'binance', toAsset: 'BBB' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('failed')
+    expect(submitNewOrderMock).not.toHaveBeenCalled()
+  })
+
+  // Idempotency: the order carries a deterministic clientOrderId derived from the
+  // transaction + step so a retry maps to the SAME order on Binance.
+  it('submits a deterministic clientOrderId derived from transactionId + step', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+
+    await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62, transactionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' } } as never,
+      stepOrder: 5,
+    })
+
+    expect(submitNewOrderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ newClientOrderId: 'aaaaaaaabbbbccccddddeeeeeeeeeeee5' }),
+    )
+  })
+
+  // Idempotency: if the order already exists (Binance rejects the duplicate
+  // clientOrderId on a retry), recover the existing fill — never re-submit.
+  // NOTE: the `binance` client throws a PLAIN OBJECT { code, message, body },
+  // NOT an axios-style Error with .response — the mock must match that contract.
+  it('recovers the existing fill on a duplicate-order rejection instead of double-submitting', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+    submitNewOrderMock.mockRejectedValue({ body: { code: -2010, msg: 'Duplicate order sent.' }, code: -2010, message: 'Duplicate order sent.' })
+    getOrderMock.mockResolvedValue({ cummulativeQuoteQty: '100.62', executedQty: '100.46', orderId: 99, status: 'FILLED' })
+    getAccountTradeListMock.mockResolvedValue([{ commission: '0.10', commissionAsset: 'USDC' }])
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62, transactionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(result.output?.amount).toBeCloseTo(100.36, 6) // recovered: 100.46 − 0.10 commission
+    expect(submitNewOrderMock).toHaveBeenCalledTimes(1) // attempted once, NOT re-submitted
+    expect(getOrderMock).toHaveBeenCalledWith(expect.objectContaining({ origClientOrderId: 'aaaaaaaabbbbccccddddeeeeeeeeeeee5', symbol: 'USDCUSDT' }))
+  })
+
+  // Money-safety on the recovery path: if the trade list (commission) can't be
+  // read, do NOT return the gross (which would over-report and oversize the
+  // withdraw) — fail so the operator retries once trades are queryable.
+  it('does not recover (fails) when the recovered order trades cannot be read', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+    submitNewOrderMock.mockRejectedValue({ body: { code: -2010, msg: 'Duplicate order sent.' }, code: -2010, message: 'Duplicate order sent.' })
+    getOrderMock.mockResolvedValue({ cummulativeQuoteQty: '100.62', executedQty: '100.46', orderId: 99, status: 'FILLED' })
+    getAccountTradeListMock.mockRejectedValue(new Error('trades unavailable'))
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62, transactionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('failed')
+  })
+
+  // A non-terminal PARTIALLY_FILLED order must not be snapshotted as the final
+  // realized amount (would under-deliver) — surface as unresolved/retryable.
+  it('does not recover (fails) when the existing order is only PARTIALLY_FILLED', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+    submitNewOrderMock.mockRejectedValue({ body: { code: -2010, msg: 'Duplicate order sent.' }, code: -2010, message: 'Duplicate order sent.' })
+    getOrderMock.mockResolvedValue({ cummulativeQuoteQty: '50.0', executedQty: '50.0', orderId: 99, status: 'PARTIALLY_FILLED' })
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62, transactionId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('failed')
+  })
+
+  // The order executed but the realized amount can't be read ⇒ fail (operator-
+  // retryable), never emit the wrong-denomination input amount downstream.
+  it('fails when a filled order returns no executed quantity (never guesses the amount)', async () => {
+    const { executor } = makeExecutor()
+    mockExchange({ USDCUSDT: USDCUSDT_INFO })
+    submitNewOrderMock.mockResolvedValue({ orderId: 7 }) // no executedQty/cummulativeQuoteQty
+
+    const result = await executor.execute({
+      config: { fromAsset: 'USDT', provider: 'binance', toAsset: 'USDC' },
+      runtime: { context: { sourceAmount: 100.62 } } as never,
+      stepOrder: 5,
+    })
+
+    expect(result.outcome).toBe('failed')
+  })
+})

--- a/abroad-server/src/tests/modules/flows/application/steps/TreasuryTransferStepExecutor.test.ts
+++ b/abroad-server/src/tests/modules/flows/application/steps/TreasuryTransferStepExecutor.test.ts
@@ -14,9 +14,10 @@ const MockedWallet = Wallet as unknown as jest.Mock
 
 const baseLogger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() }
 
-const makeExecutor = () => {
+const makeExecutor = (opts: { depositNetwork?: string } = {}) => {
   const destinationProvider = {
-    getExchangeAddress: jest.fn(async () => ({ address: 'dest-addr', memo: null, success: true })),
+    getDepositNetwork: jest.fn(() => (Object.prototype.hasOwnProperty.call(opts, 'depositNetwork') ? opts.depositNetwork : 'SOLANA')),
+    getExchangeAddress: jest.fn(async () => ({ address: 'sol-dest-addr', memo: null, success: true })),
   }
   const exchangeProviderFactory = {
     getExchangeProvider: jest.fn(() => destinationProvider),
@@ -31,11 +32,13 @@ const makeExecutor = () => {
     secretManager as never,
     baseLogger as never,
   )
-  return { executor }
+  return { destinationProvider, executor }
 }
 
+// context.blockchain is CELO (the ORIGINAL USDT deposit chain) — the transfer
+// must NOT use it. The bridge chain comes from the destination provider.
 const runtime = (sourceAmount: number) => ({
-  context: { blockchain: 'CELO', cryptoCurrency: 'USDC', sourceAmount, targetCurrency: 'BRL' },
+  context: { blockchain: 'CELO', cryptoCurrency: 'USDT', sourceAmount, targetCurrency: 'BRL' },
   stepOutputs: new Map(),
 })
 
@@ -46,14 +49,31 @@ describe('TreasuryTransferStepExecutor', () => {
     MockedWallet.mockClear()
     withdrawMock.mockResolvedValue({ data: async () => ({ id: 'withdraw-1' }) })
     allCoinsMock.mockResolvedValue({
-      data: async () => ([{ coin: 'USDC', networkList: [{ isDefault: true, network: 'MATIC', withdrawFee: '0.8' }] }]),
+      data: async () => ([{ coin: 'USDC', networkList: [{ network: 'SOL', withdrawFee: '0.8' }] }]),
     })
   })
 
-  // The next hop (final Transfero convert) must convert what actually ARRIVES,
-  // so the transfer must report the credited amount = withdrawn − network fee,
-  // not the gross withdrawal amount.
-  it('outputs the credited amount = withdrawn minus the network withdrawal fee', async () => {
+  // The deposit address AND the Binance withdraw network must both be derived
+  // from the destination provider's bridge chain for the ASSET being moved —
+  // never from the origin deposit chain (CELO). Funds must go to Solana.
+  it('bridges on the destination provider network (Solana), ignoring the origin deposit chain (CELO)', async () => {
+    const { destinationProvider, executor } = makeExecutor()
+
+    const result = await executor.execute({
+      config: { asset: 'USDC', destinationProvider: 'transfero', sourceProvider: 'binance' },
+      runtime: runtime(100) as never,
+      stepOrder: 6,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(destinationProvider.getDepositNetwork).toHaveBeenCalledWith({ cryptoCurrency: 'USDC' })
+    // Address resolved on SOLANA + the transferred asset (USDC), NOT CELO/USDT.
+    expect(destinationProvider.getExchangeAddress).toHaveBeenCalledWith({ blockchain: 'SOLANA', cryptoCurrency: 'USDC' })
+    // Withdraw network token maps from the SAME bridge chain (SOLANA -> SOL).
+    expect(withdrawMock).toHaveBeenCalledWith(expect.objectContaining({ address: 'sol-dest-addr', coin: 'USDC', network: 'SOL' }))
+  })
+
+  it('reports credited amount = withdrawn minus the bridge-network withdrawal fee', async () => {
     const { executor } = makeExecutor()
 
     const result = await executor.execute({
@@ -63,23 +83,21 @@ describe('TreasuryTransferStepExecutor', () => {
     })
 
     expect(result.outcome).toBe('succeeded')
-    expect(withdrawMock).toHaveBeenCalledWith(expect.objectContaining({ amount: 100.46, coin: 'USDC' }))
-    expect(result.output?.amount).toBeCloseTo(99.66, 6) // 100.46 withdrawn − 0.8 network fee
-    expect(result.output?.withdrawId).toBe('withdraw-1')
+    expect(result.output?.amount).toBeCloseTo(99.66, 6) // 100.46 − 0.8 SOL network fee
   })
 
-  // If the fee can't be determined, fall back to the gross amount (never strand).
-  it('falls back to the gross amount when the withdrawal fee is unavailable', async () => {
-    const { executor } = makeExecutor()
-    allCoinsMock.mockResolvedValue({ data: async () => ([]) })
+  // Never let Binance default-route the withdraw to the wrong chain: if the
+  // bridge network is unresolved, fail BEFORE withdrawing.
+  it('fails without withdrawing when the bridge network cannot be resolved', async () => {
+    const { executor } = makeExecutor({ depositNetwork: undefined })
 
     const result = await executor.execute({
       config: { asset: 'USDC', destinationProvider: 'transfero', sourceProvider: 'binance' },
-      runtime: runtime(100.46) as never,
+      runtime: runtime(100) as never,
       stepOrder: 6,
     })
 
-    expect(result.outcome).toBe('succeeded')
-    expect(result.output?.amount).toBeCloseTo(100.46, 6)
+    expect(result.outcome).toBe('failed')
+    expect(withdrawMock).not.toHaveBeenCalled()
   })
 })

--- a/abroad-server/src/tests/modules/flows/application/steps/TreasuryTransferStepExecutor.test.ts
+++ b/abroad-server/src/tests/modules/flows/application/steps/TreasuryTransferStepExecutor.test.ts
@@ -1,0 +1,85 @@
+import { Wallet } from '@binance/wallet'
+
+import { TreasuryTransferStepExecutor } from '../../../../../modules/flows/application/steps/TreasuryTransferStepExecutor'
+
+const withdrawMock = jest.fn()
+const allCoinsMock = jest.fn()
+jest.mock('@binance/wallet', () => ({
+  Wallet: jest.fn().mockImplementation(() => ({
+    restAPI: { allCoinsInformation: allCoinsMock, withdraw: withdrawMock },
+  })),
+}))
+
+const MockedWallet = Wallet as unknown as jest.Mock
+
+const baseLogger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() }
+
+const makeExecutor = () => {
+  const destinationProvider = {
+    getExchangeAddress: jest.fn(async () => ({ address: 'dest-addr', memo: null, success: true })),
+  }
+  const exchangeProviderFactory = {
+    getExchangeProvider: jest.fn(() => destinationProvider),
+    getExchangeProviderForCapability: jest.fn(() => destinationProvider),
+  }
+  const secretManager = {
+    getSecret: jest.fn(async () => 'secret'),
+    getSecrets: jest.fn(async () => ({})),
+  }
+  const executor = new TreasuryTransferStepExecutor(
+    exchangeProviderFactory as never,
+    secretManager as never,
+    baseLogger as never,
+  )
+  return { executor }
+}
+
+const runtime = (sourceAmount: number) => ({
+  context: { blockchain: 'CELO', cryptoCurrency: 'USDC', sourceAmount, targetCurrency: 'BRL' },
+  stepOutputs: new Map(),
+})
+
+describe('TreasuryTransferStepExecutor', () => {
+  beforeEach(() => {
+    withdrawMock.mockReset()
+    allCoinsMock.mockReset()
+    MockedWallet.mockClear()
+    withdrawMock.mockResolvedValue({ data: async () => ({ id: 'withdraw-1' }) })
+    allCoinsMock.mockResolvedValue({
+      data: async () => ([{ coin: 'USDC', networkList: [{ isDefault: true, network: 'MATIC', withdrawFee: '0.8' }] }]),
+    })
+  })
+
+  // The next hop (final Transfero convert) must convert what actually ARRIVES,
+  // so the transfer must report the credited amount = withdrawn − network fee,
+  // not the gross withdrawal amount.
+  it('outputs the credited amount = withdrawn minus the network withdrawal fee', async () => {
+    const { executor } = makeExecutor()
+
+    const result = await executor.execute({
+      config: { asset: 'USDC', destinationProvider: 'transfero', sourceProvider: 'binance' },
+      runtime: runtime(100.46) as never,
+      stepOrder: 6,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(withdrawMock).toHaveBeenCalledWith(expect.objectContaining({ amount: 100.46, coin: 'USDC' }))
+    expect(result.output?.amount).toBeCloseTo(99.66, 6) // 100.46 withdrawn − 0.8 network fee
+    expect(result.output?.withdrawId).toBe('withdraw-1')
+  })
+
+  // If the fee can't be determined, fall back to the gross amount (never strand).
+  it('falls back to the gross amount when the withdrawal fee is unavailable', async () => {
+    const { executor } = makeExecutor()
+    allCoinsMock.mockResolvedValue({ data: async () => ([]) })
+
+    const result = await executor.execute({
+      config: { asset: 'USDC', destinationProvider: 'transfero', sourceProvider: 'binance' },
+      runtime: runtime(100.46) as never,
+      stepOrder: 6,
+    })
+
+    expect(result.outcome).toBe('succeeded')
+    expect(result.output?.amount).toBeCloseTo(100.46, 6)
+  })
+})


### PR DESCRIPTION
Fixes every leg of the multi-hop `USDT/CELO → Binance(USDC) → Transfero(Solana) → BRL` corridor, which had never run end-to-end. Deployed as tags `5.6.13` and `5.6.14`; validated in prod (instance `51d6dce1` COMPLETED).

## 5.6.13 — Binance convert + amount propagation
- `FlowDefinitionBuilder` emits convert **intent** (`fromAsset`/`toAsset`); the executor resolves the real Binance symbol+side authoritatively via `exchangeInfo` (USDT→USDC ⇒ `BUY USDCUSDT`), verifying base/quote.
- Realized amounts propagate hop-to-hop (`wireAmountSources`); convert outputs the **received** amount net commission, floored.
- **Idempotent** order submission (deterministic `clientOrderId`; recover existing fill on duplicate-order rejection — no double-spend). Convert errors are terminal/operator-retryable (no un-resumable `waiting`).

## 5.6.14 — treasury-transfer bridge chain
- `IExchangeProvider.getDepositNetwork` lets a provider declare its deposit chain (Transfero USDC → Solana). The transfer derives **both** the deposit address and the Binance withdraw network from that one value (`SOLANA→'SOL'`) and **hard-fails before withdrawing** if unresolved — funds can never route to a mismatched chain. No longer uses the origin deposit chain.

All changes TDD'd; 3 adversarial review rounds. The Transfero convert (`createMarketOrder`) was deliberately left unchanged — it works against the live API (proven by completed flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)